### PR TITLE
peaShooter와 Zombie 전투 장면 구현

### DIFF
--- a/ProjectPvsZ/Assets/Ani/Zombie/Zombie.controller
+++ b/ProjectPvsZ/Assets/Ani/Zombie/Zombie.controller
@@ -1,5 +1,30 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1101 &-8914310298023787697
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Zombie Attack
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -2759420091430929816}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.8333333
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &-8554822245009790089
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -37,6 +62,7 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -6109522850662988136}
+  - {fileID: -8914310298023787697}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -176,7 +202,8 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 2089952544619854145}
-  m_StateMachineBehaviours: []
+  m_StateMachineBehaviours:
+  - {fileID: -1652721863346073780}
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
@@ -191,6 +218,18 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!114 &-1652721863346073780
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 528312ace320f5a45880c48483673496, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1102 &-762647877224799452
 AnimatorState:
   serializedVersion: 6
@@ -233,13 +272,13 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 10
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Zombie Attack
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -303,6 +342,18 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!114 &2897174623994640240
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 889e1aa26e5a92342a4e6d4408e7bb71, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1102 &3038987467639709064
 AnimatorState:
   serializedVersion: 6

--- a/ProjectPvsZ/Assets/Scenes/Main.unity
+++ b/ProjectPvsZ/Assets/Scenes/Main.unity
@@ -221,8 +221,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_AssetsPPU: 1
-  m_RefResolutionX: 640
-  m_RefResolutionY: 360
+  m_RefResolutionX: 960
+  m_RefResolutionY: 540
   m_UpscaleRT: 0
   m_PixelSnapping: 0
   m_CropFrameX: 0
@@ -469,8 +469,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e67d23d75a9197c4881000de34252b35, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  hp: 6
   _BulletPrefab: {fileID: 6137151651870784252, guid: b0939a1042c2d61449210ce0bf1c1259, type: 3}
+  amount: 0
+  cooltime: 0
+  hp: 6
 --- !u!1 &1236715393
 GameObject:
   m_ObjectHideFlags: 0
@@ -604,7 +606,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1323865532}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 222, y: 71, z: 0}
+  m_LocalPosition: {x: 233, y: 70, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -649,8 +651,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a47aaa152d0e45e4da30cc585a43f68d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  hp: 10
   ZombieWalkspeed: 3
+  hp: 10
 --- !u!50 &1323865540
 Rigidbody2D:
   serializedVersion: 4

--- a/ProjectPvsZ/Assets/Scripts/Zombie.cs
+++ b/ProjectPvsZ/Assets/Scripts/Zombie.cs
@@ -7,9 +7,8 @@ public class Zombie : MonoBehaviour
 {
     Rigidbody2D rigidbody2d;
     Animator animator;
-    peaShooter peaShooter;
     [Range(1f, 50f)]
-    [SerializeField] private float ZombieWalkspeed = 3f;
+    [SerializeField] private float ZombieWalkspeed = 15f;
     private bool canWalk, canAttack;
     [Range(1, 20)]
     [SerializeField]private int hp;
@@ -24,7 +23,6 @@ public class Zombie : MonoBehaviour
     {
         rigidbody2d = GetComponent<Rigidbody2D>();
         animator = GetComponent<Animator>();
-        peaShooter = GetComponent<peaShooter>();
     }
 
     private void Start()
@@ -38,12 +36,7 @@ public class Zombie : MonoBehaviour
     private void Update()
     {
         CheckPlant();
-        CheckDeath();
-
-        if(hp <= 0)
-        {
-            Destroy(gameObject);
-        }
+        CheckHealth();
     }
     // Update is called once per frame
     void FixedUpdate()
@@ -61,18 +54,27 @@ public class Zombie : MonoBehaviour
     }
 
     // 좀비 죽음 확인
-    void CheckDeath()
+    void CheckHealth()
     {
+
+        if (hp <= 2)
+        {
+            animator.SetInteger("Zombie Health", 2);
+            canAttack = false;
+        }
+
         if (hp <= 0)
         {
-            Destroy(gameObject);
+            animator.SetInteger("Zombie Health", 0);
+            canWalk = false;
+            Invoke("ZombieDeath", 1.1f);
         }
     }
 
     // 식물 감지
     void CheckPlant()
     {
-        RaycastHit2D hit = Physics2D.Raycast(transform.position, -Vector2.right, 0.3f, LayerMask.GetMask("Plants"));
+        RaycastHit2D hit = Physics2D.Raycast(transform.position, Vector2.left, 0.3f, LayerMask.GetMask("Plants"));
         if (hit.collider != null)
         {
             animator.SetBool("Zombie Attack", true);
@@ -89,9 +91,6 @@ public class Zombie : MonoBehaviour
             canWalk = true;
         }
     }
-
-   
-
     // 코루틴
     IEnumerator Eating(Collider2D collider)
     {
@@ -111,5 +110,10 @@ public class Zombie : MonoBehaviour
         {
             hp--;
         }
+    }
+    
+    void ZombieDeath()
+    {
+        Destroy(gameObject);
     }
 }

--- a/ProjectPvsZ/Assets/Scripts/ZombieLostHeadAttack.cs
+++ b/ProjectPvsZ/Assets/Scripts/ZombieLostHeadAttack.cs
@@ -1,0 +1,36 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ZombieLostHeadAttack : StateMachineBehaviour
+{
+    // OnStateEnter is called when a transition starts and the state machine starts to evaluate this state
+    //override public void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    //{
+    //    
+    //}
+
+    // OnStateUpdate is called on each Update frame between OnStateEnter and OnStateExit callbacks
+    //override public void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    //{
+    //    
+    //}
+
+    // OnStateExit is called when a transition ends and the state machine finishes evaluating this state
+    //override public void OnStateExit(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    //{
+    //    
+    //}
+
+    // OnStateMove is called right after Animator.OnAnimatorMove()
+    //override public void OnStateMove(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    //{
+    //    // Implement code that processes and affects root motion
+    //}
+
+    // OnStateIK is called right after Animator.OnAnimatorIK()
+    //override public void OnStateIK(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    //{
+    //    // Implement code that sets up animation IK (inverse kinematics)
+    //}
+}

--- a/ProjectPvsZ/Assets/Scripts/ZombieLostHeadAttack.cs.meta
+++ b/ProjectPvsZ/Assets/Scripts/ZombieLostHeadAttack.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 528312ace320f5a45880c48483673496
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# PR을 하기 전 체크사항
PR 전에 아래의 내용을 수행했는지 하나씩 체크해봅시다.

<!-- 체크 표시는 []에 x를 넣어 [x]로 만들면 됩니다. 자세한 건 [여기](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists)를 참고하세요 -->
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
달라진 기능에는 무엇이 있는지 목록으로 작성합니다.

- 좀비에 체력에 맞춰 애니메이션이 변합니다.
- 체력을 다 소진하면 좀비는 사망합니다.
- 머리가 없는 상태에서 공격은 데미지가 들어가지 않습니다.

# 제안 사항
위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다.

- 좀비가 Bullet에 충돌 할 때마다 체력이 감소되도록 만들어줬습니다.
> 좀비에 체력이 0이되면 사망하도록 구현하기 위해서입니다.

- 좀비가 머리가 없는 상태에서 공격할 때 데미지가 전혀 없도록 만들어줬습니다.
> 실제 Plants vs Zombies 게임에서 머리가 없는 상태에서 좀비들의 공격력은 0입니다.

# (선택)스크린샷
![image](https://user-images.githubusercontent.com/120005332/231150687-4186740e-b282-413b-846c-42683d39a93e.png)
![image](https://user-images.githubusercontent.com/120005332/231150819-2b91e851-1671-4761-92af-7eb89664beda.png)
![image](https://user-images.githubusercontent.com/120005332/231150966-48914838-73fb-4b5a-b259-68063f7eda4b.png)
![image](https://user-images.githubusercontent.com/120005332/231153126-78207384-8268-4d24-ba12-48c657460a2d.png)

